### PR TITLE
Fixed 'Value cannot be null. Param…eter name: key' bug

### DIFF
--- a/Rotativa.NetCore/AsResultBase.cs
+++ b/Rotativa.NetCore/AsResultBase.cs
@@ -155,7 +155,7 @@ namespace Rotativa.NetCore
 
             var cookieOptions = context.HttpContext.RequestServices.GetService<IOptions<CookieAuthenticationOptions>>();
 
-            if (cookieOptions.Value != null)
+            if (cookieOptions.Value != null && !String.IsNullOrEmpty(cookieOptions.Value.CookieName))
             {
                 var cookieName = cookieOptions.Value.CookieName;
 


### PR DESCRIPTION
In AsResultBase.GetWkParams method fixed 'Value cannot be null. Param…eter name: key' bug (see [this stack overflow post](https://stackoverflow.com/questions/45753839/pdf-generation-using-rotativa-netcore))